### PR TITLE
Recognize reserved words in variable and constant declaration

### DIFF
--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -1203,9 +1203,8 @@ contexts:
           pop: 1
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
-          pop: 1
-        - include: reserved-word-pop
-        - match: '{{identifier}}'
+          pop: 1        
+        - match: '{{non_reserved_identifier}}'
           scope: meta.entity.name.let.swift variable.other.constant.swift
         # For value-binding
         - match: \(\s*({{identifier}})
@@ -1219,6 +1218,7 @@ contexts:
             - match: ({{identifier}})
               captures:
                 1: meta.entity.name.let.swift variable.other.constant.swift
+        - include: reserved-word-pop
         - include: else-pop
 
   declaration-variable:
@@ -1231,9 +1231,8 @@ contexts:
           pop: 1
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
-          pop: 1
-        - include: reserved-word-pop
-        - match: '{{identifier}}'
+          pop: 1        
+        - match: '{{non_reserved_identifier}}'
           scope: meta.entity.name.var.swift variable.other.swift
         # For value-binding
         - match: \(\s*({{identifier}})
@@ -1247,6 +1246,7 @@ contexts:
             - match: ({{identifier}})
               captures:
                 1: meta.entity.name.let.swift variable.other.constant.swift
+        - include: reserved-word-pop
         - include: else-pop
 
   declaration-typealias:

--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -1204,6 +1204,7 @@ contexts:
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
           pop: 1
+        - include: reserved-word-pop
         - match: '{{identifier}}'
           scope: meta.entity.name.let.swift variable.other.constant.swift
         # For value-binding
@@ -1231,6 +1232,7 @@ contexts:
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
           pop: 1
+        - include: reserved-word-pop
         - match: '{{identifier}}'
           scope: meta.entity.name.var.swift variable.other.swift
         # For value-binding

--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -1203,7 +1203,7 @@ contexts:
           pop: 1
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
-          pop: 1        
+          pop: 1
         - match: '{{non_reserved_identifier}}'
           scope: meta.entity.name.let.swift variable.other.constant.swift
         # For value-binding
@@ -1231,7 +1231,7 @@ contexts:
           pop: 1
         - match: ':'
           scope: punctuation.separator.annotation.type-annotation.swift
-          pop: 1        
+          pop: 1
         - match: '{{non_reserved_identifier}}'
           scope: meta.entity.name.var.swift variable.other.swift
         # For value-binding


### PR DESCRIPTION
If there was a variable declaration that was not followed by a type annotation and the next line started a function declaration, the function declaration was not recognized.

Fixed by including reserved-word-pop before matching the variable identifier.

Resolves #4

I hope this doesn't introduce new problems, but I visually checked it against the included test files and against my own code base and couldn't find a problem.